### PR TITLE
enable hidden links

### DIFF
--- a/_data/links.json
+++ b/_data/links.json
@@ -20,7 +20,8 @@
   "label": "mastodon",
   "icon-class": "fa-brands fa-mastodon",
   "color": "#6364ff",
-  "url": "https://mastodon.social/@jasontenpenny"
+  "url": "https://mastodon.social/@jasontenpenny",
+  "hidden": true
 },
 {
   "label": "links",
@@ -31,5 +32,23 @@
   "label": "email",
   "icon-class": "fa-solid fa-envelope",
   "url": "hello@jasontenpenny.com"
+},
+{
+  "label": "mastodon",
+  "icon-class": "fa-brands fa-mastodon",
+  "url": "https://bsky.brid.gy/ap/did:plc:so3xt2f546bwafa3qhjzr3ph",
+  "hidden": true
+},
+{
+  "label": "mastodon",
+  "icon-class": "fa-brands fa-mastodon",
+  "url": "https://bsky.brid.gy/ap/jasontenpenny.com",
+  "hidden": true
+},
+{
+  "label": "mastodon",
+  "icon-class": "fa-brands fa-mastodon",
+  "url": "https://mastodon.social/@itsjason",
+  "hidden": true
 }
 ]

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,7 @@ layout: default.html
         <p>{{ site.about }}</p>
                 <section class="social-links">
             {%- for link in links -%}
-                <div class="social-link link-{{ link.label }}">
+                <div class="social-link link-{{ link.label }}" {%- if link.hidden -%}style="display: none;"{%- endif -%}>
                     {%- if link.label == "email" -%}
                     {% assign address = link.url | split: '@' %}
                     <a href="javascript:location.href = 'mailto:' + ['{{ address[0] }}','{{ address[1] }}'].join('@')">


### PR DESCRIPTION
added the ability to hide links. This is useful for Mastodon link verification even when you don't want to display the icon